### PR TITLE
Update vibrational tutorial with current schema

### DIFF
--- a/tutorial-folder/vibrational.md
+++ b/tutorial-folder/vibrational.md
@@ -1,84 +1,149 @@
-### Vibrational averaging
+## Vibrational averaging
 
-#### What is vibrational averaging?
+### What is vibrational averaging?
 
-The term vibrational averaging refers to a set of methods used to approximate the effects of thermal and quantum motion of nuclei on the expectation values of properties of light atoms. These effects are highly significant for muonium. All methods involve calculating the phonon modes of a molecule and displacing the atoms along those modes. A grid of displacements is thus created for each atom desired. The desired property is then sampled at each point on the grid and averaged using some weighting. See this [paper by B. Monserrat](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.93.014302) for more information.
+ Usually, the static lattice approximation is used in calculating properties of a system (e.g. in the ab initio DFT code CASTEP). This approximation assumes that all nuclei are static, classical objects whilst electrons have their quantum nature treated in full. However, for light nuclei in atoms such as muonium, quantum effects are highly important and neglecting them can produce inaccurate results. The term vibrational averaging refers to a set of methods used to approximate quantum effects on nuclei by "vibrating" the nuclei and averaging properties along those vibrations.
 
-`pymuon-suite` implements a general, high-level vibrational averaging function that can displace an atom in a molecule along its phonon modes and then average a quantity calculated at all displacement points with any chosen weighting. Multiple atoms can be selected, allowing this process to be repeated with whatever atoms you wish to displace. This allows it to easily be extended to use many vibrational averaging methods on many physical properties.
+These methods typically involve calculating the vibrational modes of a molecule and displacing the atoms along those modes. A grid of displacements is thus created for each atom. The desired property is then sampled at each point on the grid and averaged using some weighting. See this [paper by B. Monserrat](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.93.014302) for more information.
 
-Currently, however, only the calculation of hyperfine coupling tensors with a harmonic oscillator wavefunction as the weighting is implemented. This treats the atoms as particles in a quantum harmonic oscillator and, as such, weights the values at grid points with the wavefunction of the harmonic oscillator.
+### The `pymuon-suite` implementation
 
-New capabilities can be implemented if you are familiar with Python and willing to implement new weighting generators and data parsers.
+`pm-nq`, the section of `pymuonsuite` relating to nuclear quantum effects, implements a general, high-level vibrational averaging function that can be extended to multiple methods and physical properties. The general workflow is as follows:
 
-It should be noted that `pymuon-suite` does not displace multiple atoms simultaneously, only one at a time. Then for each atom displaced it will generate an average of the property which will have varied for all atoms due to the displacement of that one atom.
+1. Calculate the phonon modes of a molecule or crystal containing a muon using CASTEP or DFTB+
+2. Use `pm-nq` to write out a set of structure files in which the muon is displaced from its equilibrium position along the phonon mode eigenvectors
+3. Calculate the value of the desired property at each displacement (also referred to as a grid point)
+4. Use `pm-nq` to calculate an average for the property over all displacements
+
+The following are the methods that are currently implemented and ready for use:
+
+#### Independent sampling
+
+This method treats the muonium as an isolated particle in a 3-D harmonic oscillator. The muonium is displaced independently in `grid_n` increments along each of its 3 most significant phonon modes. Other atoms in the system are not displaced. The muonium can be treated like this due to its low mass relative to other chemical species, which means that its vibrations are effectively decoupled from the rest of the system.
+
+The average over the displacements will be weighted by the wavefunction of the harmonic oscillator.
+
+#### Monte Carlo sampling
+
+Monte Carlo integration can be used to give the expectation value for a desired observable. Here we sample `grid_n` points distributed according to the nuclear density at a given temperature. This in turn is given by a product of Gaussians, one for each mode in the system, whose width is temperature dependent. 
+
+Increasing system size should not increase the number of sampling points required for a constant level of accuracy. This typically makes Monte Carlo integration cheaper than alternatives once the system becomes larger than a few hundred atoms.
+
+### Using `pm-nq`
+
+If `pymuonsuite` has been installed (see tutorials section), then `pm-nq` can be called from the command line. The write mode will require a YAML-format parameter file for `pm-nq`, the format and options of which are described in the parameter file section below, and also a file representing the structure of interest in a format readable by ASE. To call the write mode enter:
+
+```
+pm-nq "<structure>" "<parameter_file>" -t w
+```
+
+This will write out a set of files with the muon displaced according to one of the methods described above. Each displacement will be located in a directory with the format `<structure>_displaced_<n>` (but with the file extension of `<structure>` removed). 
+
+If the independent sampling method is used, then `grid_n*3` files will be written, with the first third being displacements along the muon's first major phonon mode, the second third corresponding to the second mode and so forth. If the Monte Carlo method is used then `grid_n` files will be written.
+
+Once the displaced files have been generated, you must calculate the desired quantity for each, keeping the resulting data files in the same directory structure. The read/average mode can then be called by changing or omitting the task flag `-t`:
+
+```
+pm-nq "<structure>" "<parameter_file>" -t r
+```
+
+This will perform the appropriate average over the data files and produce a `averages.dat` file with the averaged quantities, alongside other files depending on the method used and property averaged over.
 
 #### The parameter file
 
-In order to use the vibrational averaging function, a YAML format parameter file must be created. The YAML format in this case is simply a set of entries, each on its own line, given by a parameter-value pair which are seperated by a colon. The list of required parameters is given below along with an example file.
+In order to use the vibrational averaging function, a YAML format parameter file must be created. The YAML format in this case is simply a set of entries, each on its own line, given by a parameter-value pair which are separated by a colon. All parameters are optional, and will use a default value if not provided:
 
-**Mandatory Parameters**
+* method: Method to be used. Currently accepted values:
+	* independent (independent sampling)
+	* montecarlo (Monte Carlo sampling)
 
-* cell_file: Path of CASTEP .cell file, or just the filename if in working directory.
+  Default: independent
 
-* muon_symbol: Symbol used to represent the muon custom species in the .cell file.
+* mu_index: Index of the muon in the cell, starting from 0. This is only used if mu_symbol is not found within the structure, in which case the atom with this index will be renamed to match mu_symbol.
 
-* atom_indices: An array of indices of the atoms to be vibrated, counting from 1. For example, for the first 3 atoms in the system, [1, 2, 3] would be input. Enter [-1] to select all atoms.
+  Default: -1 (the last atom in the structure)
 
-* grid_n: Number of grid points to use along each phonon mode.
+* mu_symbol: Symbol used to represent the muon custom species in the .cell file.
 
-* property: Property to be calculated. Currently accepted values: 
-	* hyperfine (hyperfine coupling tensors, rank matrix).
+  Default: H:mu
 
-* value_type: Rank of quantity being calculated. Accepted values: matrix, vector, scalar.
+* grid_n: Number of grid points to use along each phonon mode, or number of points to sample when using Monte Carlo.
 
-**Optional Parameters**
+  Default: 20
 
-These parameters will be set to a default value if not given.
+* k_points_grid: List of three integer k-points for both phonon and hyperfine calculations.
 
-* weight: Type of weighting to be used. Currently accepted values: 
-	* harmonic (harmonic oscillator wavefunction).
- 
-  Default: harmonic.
+  Default: [1,1,1]
 
-* param_file: Path of CASTEP .param file, which will be copied into the new file structure with the displaced cell files if specified. Default: None.
+* avgprop: Property to be calculated. Currently accepted values: 
+	* hyperfine (hyperfine coupling tensors.)
+	* charge
 
-* numerical_solver: If True, solve the Schroedinger equation numerically if QLab is installed. Otherwise, solve analytically. Default: False.
+  Default: hyperfine
 
-* ase_phonons: If True, calculate phonon modes of the system using ASE and CASTEP. Otherwise, read in phonons from .phonon file in same directory as .cell file. Default: False.
+* calculator: What to use to calculate the avgprop. Currently accepted values: 
+	* castep
+	* dftb+
 
-* dftb_phonons: If True, and ase\_phonons is also True, ASE will calculate phonon modes using DFTB+ rather than CASTEP. This is much quicker but also less accurate. Brief testing has shown this to agree well with CASTEP on the direction of phonon modes and agree to within an order of magnitude for large phonon frequencies. Default: True.
+  Default: castep
+
+* write_allconf: Whether to write a collective file with all displaced positions in one.
+
+  Default: false
+
+* phonon_source_file: The location of the source file for phonon modes. If not provided, it is assumed to follow the default naming convention of the phonon_source_type.
+
+  Default: None
+
+* phonon_source_type: How to read the phonons. Currently accepted values: 
+	* castep
+	* dftb+
+
+  Default: castep
+
+* displace_T: The temperature in Kelvin to use when performing the Monte Carlo sampling.
+
+  Default: 0
+
+* average_T: The temperature to use when averaging the property. If not provided, the value specified for displace_T will be used.
+
+  Default: None
+
+* castep_param: Path of CASTEP .param file, which will be copied with the displaced cell files if specified. 
+
+  Default: None
+
+* script_file: Path of a submission script, which will be copied with the displaced cell files if specified. 
+
+  Default: None
+
+* dftb_pbc: Whether to use periodic boundary conditions in DFTB+
+
+  Default: true
+
+* dftb_set: Parametrization for DFTB+. Currently accepted values: 
+	* 3ob-3-1
+	* pbc-0-3
+
+  Default: 3ob-3-1
+
+* average_file: Path to write the averages to.
+
+  Default: averages.dat
+
+* random_seed: Random seed to use for generation.
+
+  Default: None
 
 **Example Parameter File**
 
 ```
-cell_file: muon_benzene.cell
-muon_symbol: H:1
-atom_indices:[1, 2, 5, 49]
-grid_n: 20
-property: hyperfine
-value_type: matrix
-weight: harmonic
-param_file: muon_benzene.param
+phonon_source_file: ethyleneMu_opt.phonons.pkl
+phonon_source_type: dftb+
+calculator:         dftb+
+avgprop:            charge
+write_allconf:      true
+dftb_pbc:           false
+grid_n:             2
+mu_index:           -1
 ```
-
-#### Using `pymuon-suite`'s vibrational averaging function
-
-If `pymuon-suite` has been installed, the vibrational averaging function can be called through the command line using the command `pm-nq "vib_avg" "<parameter file>" -w`, where `<parameter file>` should be replaced with the path of the YAML file made earlier. The `-w` flag appended to the end of the command activates the write mode, removing it activates the averaging mode.
-
-The first step is to use `pymuon-suite`'s write mode to generate a set of cell files with the selected atoms displaced along their 3 major phonon modes. This requires a CASTEP cell file and the system's phonon modes. The phonon modes can be taken from a seperate CASTEP phonon calculation. The .phonon file should have the same name as the .cell file, e.g. "muon_benzene.cell" and "muon\_benzene.phonon". Alternatively, `pymuon-suite` can use ASE to calculate the modes when it is called if the ase\_phonons parameter is set to True.
-
-The new cell files will be split up into a file structure with a folder for each atom displaced, each containing subfolders for the modes of the respective atom which are further subdivided into folders for each grid point along that mode, like so:
-
-```
-top folder/
-	  atom/
-	      mode/
-		  grid point/
-			    molecule.cell
-			    molecule.param
-```
-
-You will then need to calculate the desired property at each grid point, making sure the resulting data file is kept in the same folder as the grid point's cell file. Unfortunately, `pymuon-suite` can not yet do this automatically so you will have to write a script to set off all of the calculations.
-
-After the property data at each grid point has been obtained, `pymuon-suite`'s averaging mode can be used to average this data. To do this, call the function as before but remove the `-w` flag. This will produce a file containing the averaged tensors of the calculated property for every atom in the system, under top\_folder/atom/molecule_tensors.dat. Additional information on the calculation may be produced and other important information depending on the property calculated. For example, if the hyperfine property is calculated then a hyperfine report will be produced detailing the hyperfine coupling constant and dipolar hyperfine components for the atom displaced and its nearest hydrogen atom (ipso hydrogen).
-

--- a/tutorial-folder/vibrational.md
+++ b/tutorial-folder/vibrational.md
@@ -71,6 +71,10 @@ In order to use the vibrational averaging function, a YAML format parameter file
 
   Default: 20
 
+* sigma_n: Number of sigma to sample up to when using the independent method.
+
+  Default: 3
+
 * k_points_grid: List of three integer k-points for both phonon and hyperfine calculations.
 
   Default: [1,1,1]

--- a/tutorials.md
+++ b/tutorials.md
@@ -23,7 +23,7 @@ this could be a good point to start!
 
 * [Installing `pymuon-suite`](tutorial-folder/installing)
 
-#### Simulating Nuclear Quantum Effects
+#### Nuclear Quantum Effects
 
 * [Performing vibrational averaging calculations](tutorial-folder/vibrational)
 


### PR DESCRIPTION
Based on #2, update the vibrational tutorial to represent the current state of `pm-nq` and the arguments it requires. #2 has been superseded by other changes since 2019, so should also be closed once this is merged.

Closes #17
Closes #2 
